### PR TITLE
Fix reset bug

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -9,8 +9,6 @@ class Game {
     this.context = context;
     this.squareHeight = 50;
     this.squareWidth = 67;
-    this.turtles = [];
-    this.logs = [];
     this.autos = [];
     this.river = [];
     this.image = image;

--- a/lib/home.js
+++ b/lib/home.js
@@ -7,7 +7,7 @@ class Home {
     this.yCoordinate = y;
     this.width = squareWidth;
     this.height = squareHeight;
-    this.color = 'black' //'#000047'
+    this.color = '#000047' //'black'
     this.timer = timer;
     this.score = score;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ let image = document.getElementById('source');
 let startButton = document.getElementById('play-game');
 let resetButton = document.getElementById('reset-game');
 let game = new Game(canvas, context, image);
+let quitLoop = false;
 // let toadImage = document.getElementById('toadSource');
 
 var sourceX = 53;
@@ -154,12 +155,21 @@ function startGame() {
     game.collisionDetection();
     game.toad.drawToad(context);
     game.checkForWin();
-    requestAnimationFrame(gameLoop);
+    if (quitLoop) {
+      restartGame();
+    } else {
+      requestAnimationFrame(gameLoop);
+    }
   })
 
 }
 
 function resetGame() {
+  quitLoop = true;
+}
+
+function restartGame() {
+  quitLoop = false;
   game.level.currentLevel = 1;
   game.score.current = 0;
   game.toad.respawnToad();


### PR DESCRIPTION
Reset button was starting multiple gameLoops.

Original test was too slow - the reset game toggled the loop break boolean off and on before the animation loop finished. The condition was never met.

The fix changes the reset button to toggle the boolean. The gameLoop controls the reset game function; it finishes the draw then checks the boolean. It triggers the reset function that toggles the boolean.